### PR TITLE
Bump to v1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish_mkdocs.yml
+++ b/.github/workflows/publish_mkdocs.yml
@@ -12,17 +12,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Install Rye
         run: |
           curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
           echo "$HOME/.rye/shims" >> $GITHUB_PATH
 
-      - name: Install MkDocs & Plugins
+      - name: Install Python & MkDocs & Plugins
         run: rye sync
 
       - name: Publish document

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -15,11 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Install Rye
         run: |
           curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.5
     hooks:
       - id: ruff
         name: ruff lint check

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more information, please see full documentation [here](https://moshi4.github
 
 ## Installation
 
-`Python 3.8 or later` is required for installation.
+`Python 3.9 or later` is required for installation.
 
 **Install PyPI package:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ or automatic genome visualization figure plotting in genome analysis scripts/pip
 
 ## Installation
 
-`Python 3.8 or later` is required for installation.
+`Python 3.9 or later` is required for installation.
 
 **Install PyPI package:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ addopts = "--cov=src --tb=long -vv --cov-report=xml --cov-report=term"
 testpaths = ["tests"]
 
 [tool.ruff]
-src = ["src", "tests"]
+include = ["src/**.py", "tests/**.py"]
 line-length = 88
 
 # Lint Rules: https://docs.astral.sh/ruff/rules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Framework :: Matplotlib",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["matplotlib>=3.6.3", "biopython>=1.80", "numpy>=1.21"]
 
 [project.optional-dependencies]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -14,18 +14,14 @@ altair==5.4.1
     # via streamlit
 asttokens==2.4.1
     # via stack-data
-astunparse==1.6.3
-    # via griffe
 attrs==24.2.0
     # via jsonschema
     # via referencing
 babel==2.16.0
     # via mkdocs-material
-backcall==0.2.0
-    # via ipython
 beautifulsoup4==4.12.3
     # via nbconvert
-biopython==1.83
+biopython==1.84
     # via pygenomeviz
 black==24.8.0
 bleach==6.1.0
@@ -50,7 +46,7 @@ colorama==0.4.6
     # via mkdocs-material
 comm==0.2.2
     # via ipykernel
-contourpy==1.1.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via pytest-cov
@@ -65,6 +61,7 @@ defusedxml==0.7.1
 distlib==0.3.8
     # via virtualenv
 exceptiongroup==1.2.2
+    # via ipython
     # via pytest
 executing==2.1.0
     # via stack-data
@@ -80,7 +77,7 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via streamlit
-griffe==1.2.0
+griffe==1.3.0
     # via mkdocstrings-python
 identify==2.6.0
     # via pre-commit
@@ -93,15 +90,13 @@ importlib-metadata==8.4.0
     # via mkdocs-get-deps
     # via mkdocstrings
     # via nbconvert
-importlib-resources==6.4.4
-    # via jsonschema
-    # via jsonschema-specifications
+importlib-resources==6.4.5
     # via matplotlib
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
     # via mkdocs-jupyter
-ipython==8.12.3
+ipython==8.18.1
     # via ipykernel
 jedi==0.19.1
     # via ipython
@@ -148,12 +143,12 @@ markupsafe==2.1.5
     # via mkdocs-autorefs
     # via mkdocstrings
     # via nbconvert
-matplotlib==3.7.5
+matplotlib==3.9.2
     # via pygenomeviz
 matplotlib-inline==0.1.7
     # via ipykernel
     # via ipython
-mdit-py-plugins==0.4.1
+mdit-py-plugins==0.4.2
     # via jupytext
 mdurl==0.1.2
     # via markdown-it-py
@@ -172,7 +167,7 @@ mkdocs-autorefs==1.2.0
     # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-jupyter==0.24.8
+mkdocs-jupyter==0.25.0
 mkdocs-material==9.5.34
     # via mkdocs-jupyter
 mkdocs-material-extensions==1.3.1
@@ -183,7 +178,7 @@ mkdocstrings-python==1.11.1
     # via mkdocstrings
 mypy-extensions==1.0.0
     # via black
-narwhals==1.6.2
+narwhals==1.6.4
     # via altair
 nbclient==0.10.0
     # via nbconvert
@@ -197,7 +192,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.9.1
     # via pre-commit
-numpy==1.24.4
+numpy==2.0.2
     # via biopython
     # via contourpy
     # via matplotlib
@@ -218,7 +213,7 @@ packaging==24.1
     # via streamlit
 paginate==0.5.7
     # via mkdocs-material
-pandas==2.0.3
+pandas==2.2.2
     # via streamlit
 pandocfilters==1.5.1
     # via nbconvert
@@ -229,14 +224,10 @@ pathspec==0.12.1
     # via mkdocs
 pexpect==4.9.0
     # via ipython
-pickleshare==0.7.5
-    # via ipython
 pillow==10.4.0
     # via matplotlib
     # via streamlit
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
-platformdirs==4.3.1
+platformdirs==4.3.2
     # via black
     # via jupyter-core
     # via mkdocs-get-deps
@@ -244,7 +235,7 @@ platformdirs==4.3.1
     # via virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.5.0
+pre-commit==3.8.0
 prompt-toolkit==3.0.47
     # via ipython
 protobuf==5.28.0
@@ -270,7 +261,7 @@ pymdown-extensions==10.9
     # via mkdocstrings
 pyparsing==3.1.4
     # via matplotlib
-pytest==8.3.2
+pytest==8.3.3
     # via pytest-cov
 pytest-cov==5.0.0
 python-dateutil==2.9.0.post0
@@ -279,7 +270,6 @@ python-dateutil==2.9.0.post0
     # via matplotlib
     # via pandas
 pytz==2024.1
-    # via babel
     # via pandas
 pyyaml==6.0.2
     # via jupytext
@@ -301,7 +291,7 @@ regex==2024.7.24
 requests==2.32.3
     # via mkdocs-material
     # via streamlit
-rich==13.8.0
+rich==13.8.1
     # via streamlit
 rpds-py==0.20.0
     # via jsonschema
@@ -309,7 +299,6 @@ rpds-py==0.20.0
 ruff==0.6.4
 six==1.16.0
     # via asttokens
-    # via astunparse
     # via bleach
     # via python-dateutil
 smmap==5.0.1
@@ -350,7 +339,6 @@ typing-extensions==4.12.2
     # via black
     # via ipython
     # via mkdocstrings
-    # via rich
     # via streamlit
 tzdata==2024.1
     # via pandas
@@ -366,8 +354,6 @@ wcwidth==0.2.13
 webencodings==0.5.1
     # via bleach
     # via tinycss2
-wheel==0.44.0
-    # via astunparse
 zipp==3.20.1
     # via importlib-metadata
     # via importlib-resources

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,21 +10,19 @@
 #   universal: false
 
 -e file:.
-altair==5.3.0
+altair==5.4.1
     # via streamlit
 asttokens==2.4.1
     # via stack-data
 astunparse==1.6.3
     # via griffe
-attrs==24.1.0
+attrs==24.2.0
     # via jsonschema
     # via referencing
-babel==2.15.0
+babel==2.16.0
     # via mkdocs-material
 backcall==0.2.0
     # via ipython
-backports-strenum==1.3.1
-    # via griffe
 beautifulsoup4==4.12.3
     # via nbconvert
 biopython==1.83
@@ -34,9 +32,9 @@ bleach==6.1.0
     # via nbconvert
 blinker==1.8.2
     # via streamlit
-cachetools==5.4.0
+cachetools==5.5.0
     # via streamlit
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -54,11 +52,11 @@ comm==0.2.2
     # via ipykernel
 contourpy==1.1.1
     # via matplotlib
-coverage==7.6.0
+coverage==7.6.1
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.3
+debugpy==1.8.5
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -68,11 +66,11 @@ distlib==0.3.8
     # via virtualenv
 exceptiongroup==1.2.2
     # via pytest
-executing==2.0.1
+executing==2.1.0
     # via stack-data
 fastjsonschema==2.20.0
     # via nbformat
-filelock==3.15.4
+filelock==3.16.0
     # via virtualenv
 fonttools==4.53.1
     # via matplotlib
@@ -82,20 +80,20 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via streamlit
-griffe==0.48.0
+griffe==1.2.0
     # via mkdocstrings-python
 identify==2.6.0
     # via pre-commit
-idna==3.7
+idna==3.8
     # via requests
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via jupyter-client
     # via markdown
     # via mkdocs
     # via mkdocs-get-deps
     # via mkdocstrings
     # via nbconvert
-importlib-resources==6.4.0
+importlib-resources==6.4.4
     # via jsonschema
     # via jsonschema-specifications
     # via matplotlib
@@ -132,9 +130,9 @@ jupyterlab-pygments==0.3.0
     # via nbconvert
 jupytext==1.16.4
     # via mkdocs-jupyter
-kiwisolver==1.4.5
+kiwisolver==1.4.7
     # via matplotlib
-markdown==3.6
+markdown==3.7
     # via mkdocs
     # via mkdocs-autorefs
     # via mkdocs-material
@@ -164,26 +162,29 @@ mergedeep==1.3.4
     # via mkdocs-get-deps
 mistune==3.0.2
     # via nbconvert
-mkdocs==1.6.0
+mkdocs==1.6.1
     # via mkdocs-autorefs
     # via mkdocs-jupyter
     # via mkdocs-material
     # via mkdocstrings
-mkdocs-autorefs==1.0.1
+mkdocs-autorefs==1.2.0
     # via mkdocstrings
+    # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-jupyter==0.24.8
-mkdocs-material==9.5.31
+mkdocs-material==9.5.34
     # via mkdocs-jupyter
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-mkdocstrings==0.25.2
+mkdocstrings==0.26.1
     # via mkdocstrings-python
-mkdocstrings-python==1.10.7
+mkdocstrings-python==1.11.1
     # via mkdocstrings
 mypy-extensions==1.0.0
     # via black
+narwhals==1.6.2
+    # via altair
 nbclient==0.10.0
     # via nbconvert
 nbconvert==7.16.4
@@ -197,7 +198,6 @@ nest-asyncio==1.6.0
 nodeenv==1.9.1
     # via pre-commit
 numpy==1.24.4
-    # via altair
     # via biopython
     # via contourpy
     # via matplotlib
@@ -216,10 +216,9 @@ packaging==24.1
     # via nbconvert
     # via pytest
     # via streamlit
-paginate==0.5.6
+paginate==0.5.7
     # via mkdocs-material
 pandas==2.0.3
-    # via altair
     # via streamlit
 pandocfilters==1.5.1
     # via nbconvert
@@ -237,7 +236,7 @@ pillow==10.4.0
     # via streamlit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.2
+platformdirs==4.3.1
     # via black
     # via jupyter-core
     # via mkdocs-get-deps
@@ -248,7 +247,7 @@ pluggy==1.5.0
 pre-commit==3.5.0
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.3
+protobuf==5.28.0
     # via streamlit
 psutil==6.0.0
     # via ipykernel
@@ -269,7 +268,7 @@ pygments==2.18.0
 pymdown-extensions==10.9
     # via mkdocs-material
     # via mkdocstrings
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pytest==8.3.2
     # via pytest-cov
@@ -282,7 +281,7 @@ python-dateutil==2.9.0.post0
 pytz==2024.1
     # via babel
     # via pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via jupytext
     # via mkdocs
     # via mkdocs-get-deps
@@ -291,7 +290,7 @@ pyyaml==6.0.1
     # via pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-pyzmq==26.1.0
+pyzmq==26.2.0
     # via ipykernel
     # via jupyter-client
 referencing==0.35.1
@@ -302,12 +301,12 @@ regex==2024.7.24
 requests==2.32.3
     # via mkdocs-material
     # via streamlit
-rich==13.7.1
+rich==13.8.0
     # via streamlit
-rpds-py==0.19.1
+rpds-py==0.20.0
     # via jsonschema
     # via referencing
-ruff==0.5.6
+ruff==0.6.4
 six==1.16.0
     # via asttokens
     # via astunparse
@@ -315,11 +314,11 @@ six==1.16.0
     # via python-dateutil
 smmap==5.0.1
     # via gitdb
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
-streamlit==1.37.0
+streamlit==1.38.0
     # via pygenomeviz
 tenacity==8.5.0
     # via streamlit
@@ -332,8 +331,6 @@ tomli==2.0.1
     # via coverage
     # via jupytext
     # via pytest
-toolz==0.12.1
-    # via altair
 tornado==6.4.1
     # via ipykernel
     # via jupyter-client
@@ -359,9 +356,9 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.2
     # via requests
-virtualenv==20.26.3
+virtualenv==20.26.4
     # via pre-commit
-watchdog==4.0.1
+watchdog==4.0.2
     # via mkdocs
     # via streamlit
 wcwidth==0.2.13
@@ -369,8 +366,8 @@ wcwidth==0.2.13
 webencodings==0.5.1
     # via bleach
     # via tinycss2
-wheel==0.43.0
+wheel==0.44.0
     # via astunparse
-zipp==3.19.2
+zipp==3.20.1
     # via importlib-metadata
     # via importlib-resources

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,18 +10,18 @@
 #   universal: false
 
 -e file:.
-altair==5.3.0
+altair==5.4.1
     # via streamlit
-attrs==24.1.0
+attrs==24.2.0
     # via jsonschema
     # via referencing
 biopython==1.83
     # via pygenomeviz
 blinker==1.8.2
     # via streamlit
-cachetools==5.4.0
+cachetools==5.5.0
     # via streamlit
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -37,9 +37,9 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via streamlit
-idna==3.7
+idna==3.8
     # via requests
-importlib-resources==6.4.0
+importlib-resources==6.4.4
     # via jsonschema
     # via jsonschema-specifications
     # via matplotlib
@@ -50,7 +50,7 @@ jsonschema==4.23.0
     # via altair
 jsonschema-specifications==2023.12.1
     # via jsonschema
-kiwisolver==1.4.5
+kiwisolver==1.4.7
     # via matplotlib
 markdown-it-py==3.0.0
     # via rich
@@ -60,8 +60,9 @@ matplotlib==3.7.5
     # via pygenomeviz
 mdurl==0.1.2
     # via markdown-it-py
-numpy==1.24.4
+narwhals==1.6.2
     # via altair
+numpy==1.24.4
     # via biopython
     # via contourpy
     # via matplotlib
@@ -75,14 +76,13 @@ packaging==24.1
     # via matplotlib
     # via streamlit
 pandas==2.0.3
-    # via altair
     # via streamlit
 pillow==10.4.0
     # via matplotlib
     # via streamlit
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-protobuf==5.27.3
+protobuf==5.28.0
     # via streamlit
 pyarrow==17.0.0
     # via streamlit
@@ -90,7 +90,7 @@ pydeck==0.9.1
     # via streamlit
 pygments==2.18.0
     # via rich
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via matplotlib
@@ -102,23 +102,21 @@ referencing==0.35.1
     # via jsonschema-specifications
 requests==2.32.3
     # via streamlit
-rich==13.7.1
+rich==13.8.0
     # via streamlit
-rpds-py==0.19.1
+rpds-py==0.20.0
     # via jsonschema
     # via referencing
 six==1.16.0
     # via python-dateutil
 smmap==5.0.1
     # via gitdb
-streamlit==1.37.0
+streamlit==1.38.0
     # via pygenomeviz
 tenacity==8.5.0
     # via streamlit
 toml==0.10.2
     # via streamlit
-toolz==0.12.1
-    # via altair
 tornado==6.4.1
     # via streamlit
 typing-extensions==4.12.2
@@ -129,7 +127,7 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.2
     # via requests
-watchdog==4.0.1
+watchdog==4.0.2
     # via streamlit
-zipp==3.19.2
+zipp==3.20.1
     # via importlib-resources

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,7 +15,7 @@ altair==5.4.1
 attrs==24.2.0
     # via jsonschema
     # via referencing
-biopython==1.83
+biopython==1.84
     # via pygenomeviz
 blinker==1.8.2
     # via streamlit
@@ -27,7 +27,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via streamlit
-contourpy==1.1.1
+contourpy==1.3.0
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -39,9 +39,7 @@ gitpython==3.1.43
     # via streamlit
 idna==3.8
     # via requests
-importlib-resources==6.4.4
-    # via jsonschema
-    # via jsonschema-specifications
+importlib-resources==6.4.5
     # via matplotlib
 jinja2==3.1.4
     # via altair
@@ -56,13 +54,13 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.7.5
+matplotlib==3.9.2
     # via pygenomeviz
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==1.6.2
+narwhals==1.6.4
     # via altair
-numpy==1.24.4
+numpy==2.0.2
     # via biopython
     # via contourpy
     # via matplotlib
@@ -75,13 +73,11 @@ packaging==24.1
     # via altair
     # via matplotlib
     # via streamlit
-pandas==2.0.3
+pandas==2.2.2
     # via streamlit
 pillow==10.4.0
     # via matplotlib
     # via streamlit
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
 protobuf==5.28.0
     # via streamlit
 pyarrow==17.0.0
@@ -102,7 +98,7 @@ referencing==0.35.1
     # via jsonschema-specifications
 requests==2.32.3
     # via streamlit
-rich==13.8.0
+rich==13.8.1
     # via streamlit
 rpds-py==0.20.0
     # via jsonschema
@@ -121,7 +117,6 @@ tornado==6.4.1
     # via streamlit
 typing-extensions==4.12.2
     # via altair
-    # via rich
     # via streamlit
 tzdata==2024.1
     # via pandas

--- a/src/pygenomeviz/__init__.py
+++ b/src/pygenomeviz/__init__.py
@@ -2,7 +2,7 @@ import matplotlib as mpl
 
 from pygenomeviz.genomeviz import GenomeViz
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 __all__ = [
     "GenomeViz",

--- a/src/pygenomeviz/align/tool/base.py
+++ b/src/pygenomeviz/align/tool/base.py
@@ -175,15 +175,18 @@ class AlignToolBase(ABC):
             raise ValueError("Number of input seqs is less than 2.")
         # Parse genbank or fasta files
         parse_seqs: Sequence[Fasta | Genbank] = []
+        gbk_suffixes = (".gb", ".gbk", ".gbff", ".gb.gz", ".gbk.gz", ".gbff.gz")
+        fasta_suffixes = (".fa", ".fna", ".fasta", ".fa.gz", ".fna.gz", ".fasta.gz")
         for seq in seqs:
             if isinstance(seq, str):
                 seq = Path(seq)
             if isinstance(seq, Path):
-                gbk_suffixes = (".gb", ".gbk", ".gbff", ".gz")
-                fasta_suffixes = (".fa", ".fna", ".fasta")
-                if seq.suffix in gbk_suffixes:
+                suffix = seq.suffix
+                if suffix == ".gz" and len(seq.suffixes) >= 2:
+                    suffix = seq.suffixes[-2].join("")
+                if suffix in gbk_suffixes:
                     parse_seqs.append(Genbank(seq))
-                elif seq.suffix in fasta_suffixes:
+                elif suffix in fasta_suffixes:
                     parse_seqs.append(Fasta(seq))
                 else:
                     valid_suffixes = gbk_suffixes + fasta_suffixes

--- a/src/pygenomeviz/parser/fasta.py
+++ b/src/pygenomeviz/parser/fasta.py
@@ -102,6 +102,16 @@ class Fasta:
         """
         return {seqid: len(seq) for seqid, seq in self.get_seqid2seq().items()}
 
+    def get_seqid2record(self) -> dict[str, SeqRecord]:
+        """Get seqid & complete/contig/scaffold genome record dict
+
+        Returns
+        -------
+        seqid2record : dict[str, SeqRecord]
+            seqi & genome record dict
+        """
+        return {str(rec.id): rec for rec in self.records}
+
     def write_genome_fasta(self, outfile: str | Path) -> None:
         """Write genome fasta file
 

--- a/src/pygenomeviz/parser/fasta.py
+++ b/src/pygenomeviz/parser/fasta.py
@@ -87,10 +87,10 @@ class Fasta:
 
         Returns
         -------
-        seqid2seq : dict[str, int]
+        seqid2seq : dict[str, str]
             seqid & genome sequence dict
         """
-        return {str(rec.id): rec.seq for rec in self.records}
+        return {str(rec.id): str(rec.seq) for rec in self.records}
 
     def get_seqid2size(self) -> dict[str, int]:
         """Get seqid & complete/contig/scaffold genome size dict

--- a/src/pygenomeviz/parser/genbank.py
+++ b/src/pygenomeviz/parser/genbank.py
@@ -221,10 +221,10 @@ class Genbank:
 
         Returns
         -------
-        seqid2seq : dict[str, int]
+        seqid2seq : dict[str, str]
             seqid & genome sequence dict
         """
-        return {str(rec.id): rec.seq for rec in self.records}
+        return {str(rec.id): str(rec.seq) for rec in self.records}
 
     def get_seqid2size(self) -> dict[str, int]:
         """Get seqid & complete/contig/scaffold genome size dict

--- a/src/pygenomeviz/patches.py
+++ b/src/pygenomeviz/patches.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import partial
+
 from matplotlib.patches import FancyArrow, PathPatch
 from matplotlib.path import Path
 
@@ -85,32 +87,7 @@ class Arrow(FancyArrow):
         )
 
 
-class BigArrow(Arrow):
-    """BigArrow Patch Class"""
-
-    def __init__(
-        self,
-        start: int,
-        end: int,
-        strand: int,
-        *,
-        max_size: int,
-        show_head: bool = True,
-        shaft_ratio: float = 0.5,
-        ylim: tuple[float, float] = (-1, 1),
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            start,
-            end,
-            strand,
-            max_size=max_size,
-            bigstyle=True,
-            show_head=show_head,
-            shaft_ratio=shaft_ratio,
-            ylim=ylim,
-            **kwargs,
-        )
+BigArrow = partial(Arrow, bigstyle=True)
 
 
 class Box(PathPatch):
@@ -165,26 +142,7 @@ class Box(PathPatch):
         super().__init__(box, **kwargs)
 
 
-class BigBox(Box):
-    """BigBox Patch Class"""
-
-    def __init__(
-        self,
-        start: int,
-        end: int,
-        strand: int,
-        *,
-        ylim: tuple[float, float] = (-1, 1),
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            start,
-            end,
-            strand,
-            bigstyle=True,
-            ylim=ylim,
-            **kwargs,
-        )
+BigBox = partial(Box, bigstyle=True)
 
 
 class RoundBox(PathPatch):
@@ -255,28 +213,7 @@ class RoundBox(PathPatch):
         super().__init__(Path(verts, codes), **kwargs)
 
 
-class BigRoundBox(RoundBox):
-    """BigRoundBox Patch Class"""
-
-    def __init__(
-        self,
-        start: int,
-        end: int,
-        strand: int,
-        *,
-        max_size: int,
-        ylim: tuple[float, float] = (-1, 1),
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            start,
-            end,
-            strand,
-            bigstyle=True,
-            max_size=max_size,
-            ylim=ylim,
-            **kwargs,
-        )
+BigRoundBox = partial(RoundBox, bigstyle=True)
 
 
 class Intron(PathPatch):

--- a/src/pygenomeviz/segment/feature.py
+++ b/src/pygenomeviz/segment/feature.py
@@ -299,6 +299,7 @@ class FeatureSegment:
         *,
         plotstyle: PlotStyle = "arrow",
         arrow_shaft_ratio: float = 0.5,
+        extra_tooltip: dict[str, str] | None = None,
         label: str = "",
         text_kws: dict[str, Any] | None = None,
         **kwargs,
@@ -317,6 +318,8 @@ class FeatureSegment:
             Feature plot style (`bigarrow`|`arrow`|`bigbox`|`box`|`bigrbox`|`rbox`)
         arrow_shaft_ratio : float, optional
             Arrow shaft size ratio
+        extra_tooltip : dict[str, str] | None, optional
+            Extra tooltip dict for html figure
         label : str, optional
             Feature label text
         text_kws : dict[str, Any] | None, optional
@@ -334,6 +337,7 @@ class FeatureSegment:
             feature,
             plotstyle=plotstyle,
             arrow_shaft_ratio=arrow_shaft_ratio,
+            extra_tooltip=extra_tooltip,
             **kwargs,
         )
 

--- a/src/pygenomeviz/track/feature.py
+++ b/src/pygenomeviz/track/feature.py
@@ -428,6 +428,7 @@ class FeatureTrack(Track):
         target_seg: str | None = None,
         plotstyle: PlotStyle = "arrow",
         arrow_shaft_ratio: float = 0.5,
+        extra_tooltip: dict[str, str] | None = None,
         label: str = "",
         text_kws: dict[str, Any] | None = None,
         **kwargs,
@@ -448,6 +449,8 @@ class FeatureTrack(Track):
             Feature plot style (`bigarrow`|`arrow`|`bigbox`|`box`|`bigrbox`|`rbox`)
         arrow_shaft_ratio : float, optional
             Arrow shaft size ratio
+        extra_tooltip : dict[str, str] | None, optional
+            Extra tooltip dict for html figure
         label : str, optional
             Feature label
         text_kws : dict[str, Any] | None, optional
@@ -464,6 +467,7 @@ class FeatureTrack(Track):
             strand,
             plotstyle=plotstyle,
             arrow_shaft_ratio=arrow_shaft_ratio,
+            extra_tooltip=extra_tooltip,
             label=label,
             text_kws=text_kws,
             **kwargs,


### PR DESCRIPTION
# Change Log

### Added

- Added *extra_tooltip* argument to `add_feature()` method explicitly (#61)
- Added `get_seqid2record()` method to Fasta parser class

### Changed

- Dropped python3.8 support

### Fixed

- Fixed to skip mmseqs search for no cds genome (#58)
- Fixed `get_seqid2seq()` method incorrect return type